### PR TITLE
Monitor verify-repo releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
         - multigrain
         - semantic-expect
         - sibylline
+        - verify-repo
     allow:
       - dependency-name: "@e-n-v/env"
       - dependency-name: apposite
@@ -46,6 +47,7 @@ updates:
       - dependency-name: multigrain
       - dependency-name: semantic-expect
       - dependency-name: sibylline
+      - dependency-name: verify-repo
     versioning-strategy: increase
     open-pull-requests-limit: 25
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ This structure keeps a vulnerability or packaging problem in one published packa
 | [`multigrain`](https://www.npmjs.com/package/multigrain) | `multigrain` |
 | [`semantic-expect`](https://www.npmjs.com/package/semantic-expect) | `semantic-expect` |
 | [`sibylline`](https://www.npmjs.com/package/sibylline) | `sibylline` |
-
-`verify-repo` is intentionally deferred until a release is available that installs without unpublished workspace peer dependencies.
+| [`verify-repo`](https://www.npmjs.com/package/verify-repo) | `verify-repo` |
 
 ## Adding a package
 

--- a/fixtures/verify-repo/package-lock.json
+++ b/fixtures/verify-repo/package-lock.json
@@ -1,0 +1,119 @@
+{
+  "name": "package-sitter-verify-repo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "package-sitter-verify-repo",
+      "dependencies": {
+        "verify-repo": "0.0.3"
+      }
+    },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.11.0.tgz",
+      "integrity": "sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/verify-repo": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/verify-repo/-/verify-repo-0.0.3.tgz",
+      "integrity": "sha512-b5FLLtFLiQCZ9pETeYqJdhDFPKRQyvRrzudTkzrwtjp+4okaxh8mMYiUizOoiIhCeeMkdxZaIl4lWa6N7FkGJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.11.0",
+        "glob": "^13.0.0"
+      },
+      "bin": {
+        "verify-repo": "dist/bin.js"
+      }
+    }
+  }
+}

--- a/fixtures/verify-repo/package.json
+++ b/fixtures/verify-repo/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "package-sitter-verify-repo",
+  "private": true,
+  "type": "module",
+  "scripts": { "test": "node ../../scripts/smoke.mjs verify-repo" },
+  "dependencies": { "verify-repo": "0.0.3" }
+}

--- a/scripts/fixtures.mjs
+++ b/scripts/fixtures.mjs
@@ -16,4 +16,5 @@ export const fixtures = [
   "multigrain",
   "semantic-expect",
   "sibylline",
+  "verify-repo",
 ];

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -82,6 +82,13 @@ export async function smoke(importedPackageName, imported) {
     case "sibylline":
       assert.equal(imported.default.render("a|||(2018)b|||c", 2018), "abc");
       break;
+    case "verify-repo":
+      assert.equal(typeof imported.verify, "object");
+      assert.equal(typeof imported.createRuntime, "function");
+      assert.equal(imported.default, imported.verify);
+      assert(imported.createRuntime() instanceof imported.RepoVerificationRuntime);
+      assert(imported.collectDocs().length > 0);
+      break;
   }
 }
 


### PR DESCRIPTION
## What changed

- add an isolated `verify-repo@0.0.3` consumer fixture and lockfile
- smoke-test the published runtime, default export, runtime factory, and bundled documentation
- allow Dependabot to track `verify-repo` immediately on the six-hour Package Sitter schedule
- document the new monitored package

## Why

`verify-repo@0.0.3` is the first release with the intended bundled-package layout, so Package Sitter can now provide independent post-publish validation without resolving unpublished workspace packages.

## Validation

- installed the fixture with `npm ci --ignore-scripts`
- passed `npm audit --audit-level=high`
- passed the `verify-repo` consumer smoke test
- passed the full local 18-fixture install, audit, and smoke matrix
- passed `git diff --check`
