### PR TITLE
Allow fixture security repairs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,25 +29,6 @@ updates:
         - semantic-expect
         - sibylline
         - verify-repo
-    allow:
-      - dependency-name: "@e-n-v/env"
-      - dependency-name: apposite
-      - dependency-name: badge-roll
-      - dependency-name: becomes
-      - dependency-name: check-1-2
-      - dependency-name: correlation-vector
-      - dependency-name: dollarlint
-      - dependency-name: elementory
-      - dependency-name: emj
-      - dependency-name: fill-in-the-blank
-      - dependency-name: jest-joi
-      - dependency-name: louk
-      - dependency-name: markdown-it
-      - dependency-name: markunit
-      - dependency-name: multigrain
-      - dependency-name: semantic-expect
-      - dependency-name: sibylline
-      - dependency-name: verify-repo
     versioning-strategy: increase
     open-pull-requests-limit: 25
 


### PR DESCRIPTION
## What changed

Remove the dependency-name `allow` list from Package Sitter's npm Dependabot configuration.

## Why

Dependabot's default behavior is exactly what Package Sitter needs:

- routine version updates cover direct dependencies declared by each fixture;
- security updates cover vulnerable dependencies recorded in fixture lockfiles.

The old allowlist overrode that default and caused Dependabot's `tar` security update to fail with `all_versions_ignored`, leaving a known vulnerable transitive dependency unrepairable.

The existing cooldown exclusions still make releases of the packages we publish available to Package Sitter immediately, while other routine direct dependency updates retain the three-day cooldown.

## Validation

- YAML parses successfully
- `git diff --check`
- Confirmed the failed GitHub Dependabot job reported `all_versions_ignored` for transitive `tar`
- CodeRabbit CLI: 0 findings
