### PR TITLE
Bump dollarlint fixture to 0.1.18

### DIFF
--- a/fixtures/dollarlint/package-lock.json
+++ b/fixtures/dollarlint/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "package-sitter-dollarlint",
       "dependencies": {
-        "dollarlint": "0.1.17"
+        "dollarlint": "0.1.18"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -110,15 +110,15 @@
       }
     },
     "node_modules/dollarlint": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/dollarlint/-/dollarlint-0.1.17.tgz",
-      "integrity": "sha512-bedj88Y1YPZOc8L2fmrVt+QivMTbvwqbbBrR4RQibF3YlIgFrZlYGpVaHMuWNwHR1FImDVt2XHJWA36L+W2JLw==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/dollarlint/-/dollarlint-0.1.18.tgz",
+      "integrity": "sha512-s8IYqnVXhzuEHCVRsrDW5gsc17ZkGNDmtg9qBZsgFbZIHOl3WyuENyrjtwMZNC+GUoijRZ6unMUOaVlW9mTfEA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "jszip": "3.10.1",
         "proxy-agent": "8.0.2",
-        "tar": "7.5.19"
+        "tar": "7.5.22"
       },
       "bin": {
         "dollarlint": "run-dollarlint.js"
@@ -407,7 +407,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
       "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
@@ -494,9 +495,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/fixtures/dollarlint/package.json
+++ b/fixtures/dollarlint/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "type": "module",
   "scripts": { "test": "node ../../scripts/smoke.mjs dollarlint" },
-  "dependencies": { "dollarlint": "0.1.17" }
+  "dependencies": { "dollarlint": "0.1.18" }
 }


### PR DESCRIPTION
## Summary
- update the dollarlint smoke-test fixture to the published 0.1.18 release
- refresh its lockfile so the transitive `tar` dependency is 7.5.22

## Root cause
The fixture still pinned dollarlint 0.1.17, which retained vulnerable tar 7.5.19 and kept Dependabot alert GHSA-r292-9mhp-454m open.

## Validation
- `npm --prefix fixtures/dollarlint ci --ignore-scripts`
- `npm --prefix fixtures/dollarlint test`
- CodeRabbit review: 0 findings