### PR TITLE
Name package-sitter's production verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Deploy package-sitter checks
 
 on:
   push:


### PR DESCRIPTION
Garden verifies merge-deployed surfaces by matching the exact merge SHA to a production deployment or a workflow whose name identifies delivery. Package Sitter is a repository-as-code service, so its main-branch fixture run is its production verification. Name that workflow explicitly without changing its jobs or checks.