### PR TITLE
Repair fixture security and Multigrain v3 support

### DIFF
--- a/fixtures/jest-joi/package-lock.json
+++ b/fixtures/jest-joi/package-lock.json
@@ -1784,9 +1784,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3271,9 +3271,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4124,9 +4124,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/fixtures/jest-joi/package.json
+++ b/fixtures/jest-joi/package.json
@@ -7,5 +7,13 @@
     "jest": "30.4.2",
     "jest-joi": "1.1.19",
     "joi": "18.2.3"
+  },
+  "overrides": {
+    "minimatch@3.1.5": {
+      "brace-expansion": "1.1.18"
+    },
+    "minimatch@9.0.9": {
+      "brace-expansion": "2.1.4"
+    }
   }
 }

--- a/fixtures/multigrain/package-lock.json
+++ b/fixtures/multigrain/package-lock.json
@@ -6,51 +6,16 @@
     "": {
       "name": "package-sitter-multigrain",
       "dependencies": {
-        "multigrain": "2.0.4"
+        "multigrain": "3.0.6"
       }
     },
-    "node_modules/@iarna/toml": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-      "license": "ISC"
-    },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
+      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
-      }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/coffeescript": {
@@ -163,31 +128,32 @@
       "license": "MIT"
     },
     "node_modules/multigrain": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/multigrain/-/multigrain-2.0.4.tgz",
-      "integrity": "sha512-7UqKkIGcfwYOA7XJ3/uakk6nZatpi3KxgRQP73LHNoWlSvdY2HokhjlyPEEuUR8HLP6v8+WhJm3ruROr66h5Rw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/multigrain/-/multigrain-3.0.6.tgz",
+      "integrity": "sha512-eV0jIYCy3HCI9ZKmTo3X1Cw1EW8qPV2OrVGBqn2zGddCltqXeZYj5hoTW45sxPy+/zuWRI3GqiWdexJ2D4n8qA==",
       "license": "MIT",
       "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "clone": "^2.1.2",
         "cson": "^8.4.0",
         "json-stringify-pretty-compact": "^4.0.0",
-        "plist": "^3.1.1",
-        "yaml": "^2.8.4"
+        "plist": "^5.0.0",
+        "smol-toml": "^1.7.1",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/plist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
-      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-5.0.0.tgz",
+      "integrity": "sha512-20N+g1DvMm/DFRbsvER7tT4wDryq0WunK7VMkDaiJcKNapAnUMkTsAnacFYf8n420F4Hf6/hefgmJRkMb1M0fg==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
-        "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
       "engines": {
-        "node": ">=10.4.0"
+        "node": ">=18"
       }
     },
     "node_modules/requirefresh": {
@@ -216,6 +182,18 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/typechecker": {

--- a/fixtures/multigrain/package.json
+++ b/fixtures/multigrain/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "type": "module",
   "scripts": { "test": "node ../../scripts/smoke.mjs multigrain" },
-  "dependencies": { "multigrain": "2.0.4" }
+  "dependencies": { "multigrain": "3.0.6" }
 }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -21,7 +21,7 @@ function runDollarlint() {
   assert.equal(result.status, 0, "dollarlint --help failed");
 }
 
-export async function smoke(importedPackageName, imported) {
+export async function smoke(importedPackageName, imported, auxiliary = {}) {
   assert(
     Object.keys(imported).length > 0,
     `${importedPackageName} has no public exports`,
@@ -74,7 +74,12 @@ export async function smoke(importedPackageName, imported) {
       imported.default("# Hello").markup.has("h1");
       break;
     case "multigrain":
-      assert.equal(imported.default.yaml({ key: "value" }), "key: value\n");
+      if (typeof imported.default?.yaml === "function") {
+        assert.equal(imported.default.yaml({ key: "value" }), "key: value\n");
+      } else {
+        assert.equal(typeof imported.convert, "function");
+        assert.equal(auxiliary.multigrainYaml.stringify({ key: "value" }), "key: value\n");
+      }
       break;
     case "semantic-expect":
       assert.equal(typeof imported.makeOpenAIMatchers, "function");
@@ -103,8 +108,11 @@ async function main() {
   const consumer = [
     "const packageName = process.env.PACKAGE_SITTER_PACKAGE;",
     "const imported = await import(packageName);",
+    "const auxiliary = packageName === 'multigrain' && typeof imported.default?.yaml !== 'function'",
+    "  ? { multigrainYaml: await import('multigrain/yaml') }",
+    "  : {};",
     "const { smoke } = await import(process.env.PACKAGE_SITTER_SMOKE_MODULE);",
-    "await smoke(packageName, imported);",
+    "await smoke(packageName, imported, auxiliary);",
   ].join("\n");
   const result = spawnSync(process.execPath, ["--input-type=module", "--eval", consumer], {
     cwd: process.cwd(),


### PR DESCRIPTION
## Summary
- update the jest-joi fixture to js-yaml 3.15.1, fixing GHSA-5p4m-2wfm-xmqj
- pin both vulnerable brace-expansion major lines to their patched releases with narrow minimatch-scoped overrides
- update the Multigrain fixture from v2.0.4 to v3.0.6
- preserve v2 smoke compatibility while exercising Multigrain v3 through its tree-shakeable YAML subpath

Supersedes #121 and #122.

## Validation
- clean `npm ci`, full `npm audit`, and smoke test for fixtures/jest-joi
- clean `npm ci`, full `npm audit`, and smoke test for fixtures/multigrain
- CodeRabbit: no findings